### PR TITLE
Fix MD5 of OE-Core LICENSE file

### DIFF
--- a/recipes-txt/images/measured-image-bootimg.bb
+++ b/recipes-txt/images/measured-image-bootimg.bb
@@ -1,7 +1,7 @@
 # bootable image with tboot
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = " \
-    file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
+    file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420 \
     "
 


### PR DESCRIPTION
The measured-image-bootimg.bb recipe contained an incorrect hash of the current state of the <openembedded-core>/LICENSE file.

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>