### PR TITLE
grub-efi: fix a QA issue with debug directories

### DIFF
--- a/recipes-bsp/grub/grub-efi_git.bb
+++ b/recipes-bsp/grub/grub-efi_git.bb
@@ -81,5 +81,7 @@ FILES_${PN} += "${libdir}/grub/${GRUB_TARGET}-efi \
                 ${datadir}/grub \
                 "
 
+FILES_${PN}-dbg += "${libdir}/grub/${GRUB_TARGET}-efi/.debug"
+
 BBCLASSEXTEND = "native"
 


### PR DESCRIPTION
QA Issue: non debug package contains .debug directory: grub-efi

Signed-off-by: Derek Straka <derek@asterius.io>