### PR TITLE
Update all instances of base_contains to the new bb.utils.contains

### DIFF
--- a/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -2,11 +2,11 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
 # Enable kernel support if the feature is available on the machine.
 SRC_URI += " \
-    ${@base_contains('MACHINE_FEATURES', 'tpm', 'file://tpm.scc', '', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'tpm', 'file://tpm.cfg', '', d)} \    
-    ${@base_contains('MACHINE_FEATURES', 'txt', 'file://txt.scc', '', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'txt', 'file://txt.cfg', '', d)} \
-    ${@base_contains('DISTRO_FEATURES',  'ima', 'file://ima.scc', '', d)} \
-    ${@base_contains('DISTRO_FEATURES',  'ima', 'file://ima.cfg', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'file://tpm.scc', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'file://tpm.cfg', '', d)} \    
+    ${@bb.utils.contains('MACHINE_FEATURES', 'txt', 'file://txt.scc', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'txt', 'file://txt.cfg', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES',  'ima', 'file://ima.scc', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES',  'ima', 'file://ima.cfg', '', d)} \
 "
 

--- a/recipes-kernel/linux/linux-yocto.inc
+++ b/recipes-kernel/linux/linux-yocto.inc
@@ -2,12 +2,12 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
 # Enable kernel support if the feature is available on the machine.
 SRC_URI += " \
-    ${@base_contains('MACHINE_FEATURES', 'tpm', 'file://tpm.scc', '', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'tpm', 'file://tpm.cfg', '', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'tpm2','file://tpm2.scc','', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'tpm2','file://tpm2.cfg','', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'txt', 'file://txt.scc', '', d)} \
-    ${@base_contains('MACHINE_FEATURES', 'txt', 'file://txt.cfg', '', d)} \
-    ${@base_contains('DISTRO_FEATURES',  'ima', 'file://ima.scc', '', d)} \
-    ${@base_contains('DISTRO_FEATURES',  'ima', 'file://ima.cfg', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'file://tpm.scc', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'file://tpm.cfg', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2','file://tpm2.scc','', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2','file://tpm2.cfg','', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'txt', 'file://txt.scc', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'txt', 'file://txt.cfg', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES',  'ima', 'file://ima.scc', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES',  'ima', 'file://ima.cfg', '', d)} \
 "


### PR DESCRIPTION
Fiixes all the `NOTE: base_contains is deprecated, please use bb.utils.contains instead` messages