### PR TITLE
core-image-tpm: pull in rng-tools

### DIFF
--- a/recipes-tpm/images/core-image-tpm.inc
+++ b/recipes-tpm/images/core-image-tpm.inc
@@ -11,6 +11,7 @@ IMAGE_INSTALL += "\
 	${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'packagegroup-tpm2', '', d)} \
 	kmod \
 	udev-extraconf \
+	rng-tools \
 "
 
 inherit core-image


### PR DESCRIPTION
Pull in rng-tools to provide additional entropy to the kernel from the
TPM.