### PR TITLE
tpm2.0-tss: support packaging up man pages

### DIFF
--- a/recipes-tpm/tpm2.0-tss/tpm2.0-tss.inc
+++ b/recipes-tpm/tpm2.0-tss/tpm2.0-tss.inc
@@ -1,4 +1,4 @@
-SUMMARY = "Software stack for TPM2."
+SUMMARY = "The TCG TPM2 Software Stack"
 DESCRIPTION = "tpm2.0-tss like woah."
 SECTION = "tpm"
 
@@ -13,6 +13,7 @@ S = "${WORKDIR}/${@d.getVar('BPN',d).upper()}"
 PROVIDES = "${PACKAGES}"
 PACKAGES = " \
     ${PN}-dbg \
+    ${PN}-doc \
     libtss2 \
     libtss2-dev \
     libtss2-staticdev \


### PR DESCRIPTION
Newer versions come with man pages and they need to exist inside of a
package.