### PR TITLE
fix  tpm2.0-tools

### DIFF
--- a/recipes-tpm/tpm2-abrmd/tpm2-abrmd.inc
+++ b/recipes-tpm/tpm2-abrmd/tpm2-abrmd.inc
@@ -5,7 +5,7 @@ SECTION = "tpm"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=500b2e742befc3da00684d8a1d5fd9da"
 
-DEPENDS = "autoconf-archive dbus glib-2.0 glib-2.0-native pkgconfig libtctidevice libtss2"
+DEPENDS = "autoconf-archive-native dbus glib-2.0 glib-2.0-native pkgconfig libtctidevice libtss2"
 RDEPENDS_${PN} = "libgcc"
 
 SRC_URI = " \

--- a/recipes-tpm/tpm2-tools/tpm2-tools.inc
+++ b/recipes-tpm/tpm2-tools/tpm2-tools.inc
@@ -6,7 +6,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=91b7c548d73ea16537799e8060cea819"
 DEPENDS = "tpm2-tss openssl curl autoconf-archive-native"
 
-S = "${WORKDIR}/${BPN}-${PV}"
+S = "${WORKDIR}/git"
 inherit autotools pkgconfig
 
-SRC_URI = "https://github.com/01org/${BPN}/archive/${PV}.tar.gz"
+SRC_URI = "git://github.com/01org/tpm2.0-tools.git;protocol=git;nobranch=1"

--- a/recipes-tpm/tpm2-tools/tpm2-tools_2.1.0.bb
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_2.1.0.bb
@@ -1,5 +1,6 @@
 include tpm2-tools.inc
 
-SRC_URI[md5sum] = "e566fbc43a8afe0eae14e9ca91387f0b"
-SRC_URI[sha256sum] = "696bc0ff1d42b013f4e8fd1ea6bccf04c63e776ef0b1d0427a29eabbc3246e7b"
-SRC_URI += "file://gcc7.diff"
+SRCREV = "27d34a61cb947780ab58508dfea70e696cff185c"
+SRC_URI += " \
+    file://gcc7.diff \
+"

--- a/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
@@ -6,7 +6,3 @@ DEFAULT_PREFERENCE = "-1"
 SRCREV = "${AUTOREV}"
 PVBASE := "${PV}"
 PV = "${PVBASE}.${SRCPV}"
-
-SRC_URI = " \
-    git://github.com/01org/tpm2.0-tools.git;protocol=git;branch=master;name=tpm2.0-tools;destsuffix=tpm2.0-tools \
-"

--- a/recipes-tpm/tpm2-tss/tpm2-tss.inc
+++ b/recipes-tpm/tpm2-tss/tpm2-tss.inc
@@ -25,14 +25,14 @@ PACKAGES = " \
 "
 
 FILES_libtss2 = " \
-    ${libdir}/libsapi.so.0.0.0 \
-    ${libdir}/libmarshal.so.0.0.0 \
+    ${libdir}/libsapi.so.* \
+    ${libdir}/libmarshal.so.* \
 "
 FILES_libtss2-dev = " \
     ${includedir}/sapi \
     ${includedir}/tcti/common.h \
-    ${libdir}/libmarshal.so* \
-    ${libdir}/libsapi.so* \
+    ${libdir}/libmarshal.so \
+    ${libdir}/libsapi.so \
     ${libdir}/pkgconfig/sapi.pc \
 "
 FILES_libtss2-staticdev = " \
@@ -41,17 +41,17 @@ FILES_libtss2-staticdev = " \
     ${libdir}/libsapi.a \
     ${libdir}/libsapi.la \
 "
-FILES_libtctidevice = "${libdir}/libtcti-device.so.0.0.0"
+FILES_libtctidevice = "${libdir}/libtcti-device.so.*"
 FILES_libtctidevice-dev = " \
     ${includedir}/tcti/tcti_device.h \
-    ${libdir}/libtcti-device.so* \
+    ${libdir}/libtcti-device.so \
     ${libdir}/pkgconfig/tcti-device.pc \
 "
 FILES_libtctidevice-staticdev = "${libdir}/libtcti-device.*a"
-FILES_libtctisocket = "${libdir}/libtcti-socket.so.0.0.0"
+FILES_libtctisocket = "${libdir}/libtcti-socket.so.*"
 FILES_libtctisocket-dev = " \
     ${includedir}/tcti/tcti_socket.h \
-    ${libdir}/libtcti-socket.so* \
+    ${libdir}/libtcti-socket.so \
     ${libdir}/pkgconfig/tcti-socket.pc \
 "
 FILES_libtctisocket-staticdev = "${libdir}/libtcti-socket.*a"


### PR DESCRIPTION
With these changes I can run tpm2.0-tools in the refkit initramfs.

The tpm2-abrmd enhancement is unrelated to that, but showed up when
building for refkit, because refkit issues warnings about all new
target packages (autotools-archive, in this case).