### PR TITLE
use normal BBPATH extension mechanism

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,4 +1,4 @@
-BBPATH := "${BBPATH}:${LAYERDIR}"
+BBPATH .= ":${LAYERDIR}"
 
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend \


### PR DESCRIPTION
The canonical way of adding the current layer directory is via the .=
append operation. Including the variable itself in an assignment
happened to work for normal builds, but the yocto-check-layer failed
to handle this and failed with a "variable BBPATH references itself"
error (YOCTO #12338).

It is a bit uncertain whether that is a bug in that tool or in the
meta-measured layer, but it's faster to make meta-measured more like
other layers, which avoids the problem.