### PR TITLE
tpm2-tss: Update from 1.2.0 to 1.3.0.

### DIFF
--- a/recipes-tpm/tpm2-tss/tpm2-tss.inc
+++ b/recipes-tpm/tpm2-tss/tpm2-tss.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=500b2e742befc3da00684d8a1d5fd9da"
 
 DEPENDS = "autoconf-archive-native"
 
-S = "${WORKDIR}/${BPN}"
+S = "${WORKDIR}/${BPN}-${PV}"
 
 PROVIDES = "${PACKAGES}"
 PACKAGES = " \
@@ -57,14 +57,3 @@ FILES_libtctisocket-dev = " \
 FILES_libtctisocket-staticdev = "${libdir}/libtcti-socket.*a"
 
 inherit autotools pkgconfig
-
-do_configure_prepend () {
-	# Execute the bootstrap script, to generate src_vars.mk.
-	# The actual autotools bootstrapping is done by the normal
-	# do_configure, which does a better job with it (for example,
-	# it finds m4 macros also in the native sysroot).
-	currentdir=$(pwd)
-	cd ${S}
-	AUTORECONF=true ./bootstrap
-	cd ${currentdir}
-}

--- a/recipes-tpm/tpm2-tss/tpm2-tss_1.2.0.bb
+++ b/recipes-tpm/tpm2-tss/tpm2-tss_1.2.0.bb
@@ -1,3 +1,0 @@
-include ${BPN}.inc
-
-SRC_URI = "git://github.com/01org/${BPN}.git;protocol=git;tag=${PV};name=${BPN};destsuffix=${BPN};branch=1.x"

--- a/recipes-tpm/tpm2-tss/tpm2-tss_1.3.0.bb
+++ b/recipes-tpm/tpm2-tss/tpm2-tss_1.3.0.bb
@@ -1,0 +1,5 @@
+include ${BPN}.inc
+
+SRC_URI[md5sum] = "7556894cb04c1a9b1525ad601b2c536d"
+SRC_URI[sha256sum] = "c7d627de50394e9a02593edb1ce74e1bbac17831be726c54f689507f0c41a78a"
+SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"

--- a/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
+++ b/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
@@ -2,9 +2,22 @@ include ${BPN}.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI = "git://github.com/01org/${BPN}.git;protocol=git;branch=master;name=${BPN};destsuffix=${BPN}"
+SRC_URI = "git://github.com/tpm2-software/${BPN}.git;protocol=git;branch=master;name=${BPN};destsuffix=${BPN}"
+
+S = "${WORKDIR}/${BPN}"
 
 # https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 SRCREV = "${AUTOREV}"
 PVBASE := "${PV}"
 PV = "${PVBASE}.${SRCPV}"
+
+do_configure_prepend () {
+       # Execute the bootstrap script, to generate src_vars.mk.
+       # The actual autotools bootstrapping is done by the normal
+       # do_configure, which does a better job with it (for example,
+       # it finds m4 macros also in the native sysroot).
+       currentdir=$(pwd)
+       cd ${S}
+       AUTORECONF=true ./bootstrap
+       cd ${currentdir}
+}


### PR DESCRIPTION
We build from release tarballs instead of git now which required moving
a few things into the git recipe. The URL is updated to use the new
'tpm2-software' organization too.

Signed-off-by: Philip Tricca <flihp@twobit.us>