### PR TITLE
tpm2-tools: Upgrade recipe from 2.1.0 to 3.0.3.

### DIFF
--- a/recipes-tpm/tpm2-tools/tpm2-tools.inc
+++ b/recipes-tpm/tpm2-tools/tpm2-tools.inc
@@ -6,7 +6,6 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=91b7c548d73ea16537799e8060cea819"
 DEPENDS = "tpm2-tss openssl curl autoconf-archive-native"
 
-S = "${WORKDIR}/git"
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/01org/tpm2.0-tools.git;protocol=git;nobranch=1"
+SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"

--- a/recipes-tpm/tpm2-tools/tpm2-tools_2.1.0.bb
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_2.1.0.bb
@@ -1,6 +1,0 @@
-include tpm2-tools.inc
-
-SRCREV = "27d34a61cb947780ab58508dfea70e696cff185c"
-SRC_URI += " \
-    file://gcc7.diff \
-"

--- a/recipes-tpm/tpm2-tools/tpm2-tools_3.0.3.bb
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_3.0.3.bb
@@ -1,0 +1,4 @@
+include tpm2-tools.inc
+
+SRC_URI[md5sum] = "9c44eb0308d5bf23a02ad08b63cd37db"
+SRC_URI[sha256sum] = "c990c0656165afef0fad61e1852a9a189a4b93b43d2a684b151a5dc0b3c6249d"


### PR DESCRIPTION
This patch also switches us over to building from the release tarballs
instead of git tags.

Signed-off-by: Philip Tricca <flihp@twobit.us>