### PR TITLE
tpm2-abrmd-init.sh: fix for /dev/tpmrmX

### DIFF
--- a/recipes-tpm/tpm2-abrmd/files/tpm2-abrmd-init.sh
+++ b/recipes-tpm/tpm2-abrmd/files/tpm2-abrmd-init.sh
@@ -27,7 +27,7 @@ case "${1}" in
 	start)
 		echo -n "Starting $DESC: "
 
-		if [ ! -e /dev/tpm* ]
+		if [ ! -e /dev/tpm? ]
 		then
 			echo "device driver not loaded, skipping."
 			exit 0


### PR DESCRIPTION
Newer kernels, in addition to the traditional /dev/tpmX device nodes, are now
also creating /dev/tpmrmX device nodes. This causes this script to get
confused and abort, meaning tpm2-abrmd does not get started during boot.

Fix for https://github.com/flihp/meta-measured/issues/56

Signed-off-by: Trevor Woerner <twoerner@gmail.com>