### PR TITLE
tpm2-tools: DEPEND on abrmd

### DIFF
--- a/recipes-tpm/tpm2-tools/tpm2-tools.inc
+++ b/recipes-tpm/tpm2-tools/tpm2-tools.inc
@@ -4,7 +4,7 @@ SECTION = "tpm"
 
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=91b7c548d73ea16537799e8060cea819"
-DEPENDS = "tpm2-tss openssl curl autoconf-archive-native"
+DEPENDS = "tpm2-abrmd tpm2-tss openssl curl autoconf-archive-native"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
This layer expects to run the abrmd daemon on the target, so that the tools
interact with it

	# tpm2_pcrlist -T abrmd

(since it is running) instead of the device directly (i.e. when the daemon is
not running)

	# tpm2_pcrlist -T device:/dev/tpm0

Whether or not the tools are built to use the tabrmd depends on whether or not
the ./configure script finds the tabrmd libraries during configuration.
Without this recipe DEPENDing on the abrmd recipe, these tools will never be
built to use tabrmd as a TCTI.

Without DEPENDS:

	# tpm2_pcrlist -v
	tool="tpm2_pcrlist" version="" tctis="socket,device,"

With DEPENDS:

	# tpm2_pcrlist -v
	tool="tpm2_pcrlist" version="" tctis="tabrmd,socket,device,"

Signed-off-by: Trevor Woerner <twoerner@gmail.com>