### PR TITLE
layer.conf: define LAYERSERIES_COMPAT_measured = "sumo"

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,5 +16,7 @@ BBFILE_PRIORITY_measured = "5"
 
 LAYERDEPENDS_measured = "core"
 
+LAYERSERIES_COMPAT_measured = "sumo"
+
 # override security flags to have the packages work
 require conf/distro/include/measured_security_flags.inc


### PR DESCRIPTION
Newer versions of bitbake require each layer to explicitely state
their OE/Yocto release compatibility. The consensus is for each layer
to use the latest released version codename for the master branch.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>