### PR TITLE
trousers: pass --system to useradd/groupadd

### DIFF
--- a/recipes-tpm/trousers/trousers.inc
+++ b/recipes-tpm/trousers/trousers.inc
@@ -73,8 +73,8 @@ INITSCRIPT_PARAMS = "start 99 2 3 4 5 . stop 19 0 1 6 ."
 EXTRA_OECONF="--with-gui=none"
 
 USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM_${PN} = "tss"
-USERADD_PARAM_${PN} = "-M -d /var/lib/tpm -s /bin/false -g tss tss"
+GROUPADD_PARAM_${PN} = "--system tss"
+USERADD_PARAM_${PN} = "--system -M -d /var/lib/tpm -s /bin/false -g tss tss"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "tcsd.service"


### PR DESCRIPTION
Add --system to USERADD_PARAM/GROUPADD_PARAM to stop following QA warning from
occuring:

do_package_qa: QA Issue: trousers: /trousers/etc/tcsd.conf is owned by uid
1000, which is the same as the user running bitbake. This may be due to host
contamination [host-user-contaminated]

Signed-off-by: Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>