### PR TITLE
Add getVar argument to keep working on morty

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes-*/*/*.bbappend' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
-BBMASK += "${@'recipes-tpm/[^/]*/.*_git' if d.getVar('BB_NO_NETWORK') == '1' else ''}"
+BBMASK += "${@'recipes-tpm/[^/]*/.*_git' if d.getVar('BB_NO_NETWORK', True) == '1' else ''}"
 
 BBFILE_COLLECTIONS += "measured"
 BBFILE_PATTERN_measured := "^${LAYERDIR}/"


### PR DESCRIPTION
This small change keeps the recipes working on the yocto morty branch.