### PR TITLE
Add default dev paths to fix uninstalled dev files

### DIFF
--- a/recipes-tpm/tpm2-tss/tpm2-tss.inc
+++ b/recipes-tpm/tpm2-tss/tpm2-tss.inc
@@ -47,6 +47,7 @@ FILES_libtss2-dev = " \
     ${libdir}/pkgconfig/tss2-sys.pc \
     ${libdir}/pkgconfig/tss2-tcti-device.pc \
     ${libdir}/pkgconfig/tss2-tcti-mssim.pc \
+    ${FILES_tpm2-tss-dev} \
 "
 
 FILES_libtss2-staticdev = " \


### PR DESCRIPTION
Here's the error I get when building the tpm2-tss recipe:
```
ERROR: tpm2-tss-2.1.0-r0 do_package: QA Issue: tpm2-tss: Files/directories were installed but not shipped in any package:
  /usr/lib/libtss2-tcti-mssim.la
  /usr/lib/libtss2-esys.la
  /usr/lib/libtss2-mu.la
  /usr/lib/libtss2-tcti-device.la
  /usr/lib/libtss2-sys.la
```
The least brittle solution is to just add the default paths that normally get added to the `-dev` package.