### PR TITLE
Add pyelftools python3 support

### DIFF
--- a/recipes-devtools/pyelftools/python-pyelftools.inc
+++ b/recipes-devtools/pyelftools/python-pyelftools.inc
@@ -8,13 +8,10 @@ PR = "p0"
 LICENSE = "PD"
 S = "${WORKDIR}/git"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5ce2a2b07fca326bc7c146d10105ccfc"
-RDEPENDS_${PN} = "python python-contextlib python-debugger python-pprint"
-RDEPENDS_${PN}_class-native = "python"
+
 SRC_URI += " \
     git://github.com/eliben/pyelftools \
 "
 SRCREV = "master"
-
-inherit setuptools
 
 BBCLASSEXTEND = "native"

--- a/recipes-devtools/pyelftools/python-pyelftools_git.bb
+++ b/recipes-devtools/pyelftools/python-pyelftools_git.bb
@@ -1,0 +1,6 @@
+inherit setuptools
+require python-pyelftools.inc
+
+RDEPENDS_${PN} = "python python-contextlib python-debugger python-pprint"
+RDEPENDS_${PN}_class-native = "python"
+

--- a/recipes-devtools/pyelftools/python3-pyelftools_git.bb
+++ b/recipes-devtools/pyelftools/python3-pyelftools_git.bb
@@ -1,0 +1,6 @@
+inherit setuptools3
+require python-pyelftools.inc
+
+RDEPENDS_${PN} = "python3 python3-contextlib python3-debugger python3-pprint"
+RDEPENDS_${PN}_class-native = "python3"
+

--- a/recipes-txt/pcr-calc/pcr-calc_git.bb
+++ b/recipes-txt/pcr-calc/pcr-calc_git.bb
@@ -9,8 +9,8 @@ PR = "p0"
 LICENSE = "GPL-2.0"
 S = "${WORKDIR}/git"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-DEPENDS = "pyelftools-native"
-RDEPENDS_${PN} = "python python-argparse python-compression python-mmap python-netclient python-textutils pyelftools"
+DEPENDS = "python-pyelftools-native"
+RDEPENDS_${PN} = "python python-argparse python-compression python-mmap python-netclient python-textutils python-pyelftools"
 SRC_URI += " \
     git://github.com/flihp/pcr-calc.git \
 "


### PR DESCRIPTION
This has been implemented similarly to other python packages in meta-openembedded/meta-python/recipes-devtools/python which have a python-packagename.bb python3-packagename.bb and python-packagename.inc with the common parts.

This now allows packages to depend on python3 variant of pyelftools e.g. DEPENDS = python3-pyelftools-native