### PR TITLE
wic-image-tpm: Add recipe to build wic image for rootfs wit tpm stuff.

### DIFF
--- a/recipes-tpm/images/wic-image-tpm.bb
+++ b/recipes-tpm/images/wic-image-tpm.bb
@@ -1,0 +1,18 @@
+SUMMARY = "a bootable image with tpm stuff using wic"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
+    "
+
+require recipes-tpm/images/core-image-tpm.inc
+
+SRC_URI = "file://${FILE_DIRNAME}/${BPN}.wks.in"
+
+IMAGE_FSTYPES = "wic"
+
+WKS_FILE = "${BPN}.wks.in"
+WKS_FILE_DEPENDS = "dosfstools-native mtools-native gptfdisk-native"
+
+RDEPENDS_wic-image-tpm = "grub-efi"
+
+IMAGE_ROOTFS_EXTRA_SPACE = "2000"

--- a/recipes-tpm/images/wic-image-tpm.wks.in
+++ b/recipes-tpm/images/wic-image-tpm.wks.in
@@ -1,0 +1,7 @@
+# Create EFI disk image with tpm stuff on readonly rootfs
+
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --ondisk sda --label boot --active --align 1024
+part / --source rootfs --rootfs-dir=${BPN} --ondisk sda --fstype=ext4 --label rootfs --align 1024 --use-uuid
+part swap --ondisk sda --size 44 --label swap --fstype=swap
+
+bootloader --ptable gpt --timeout=5 --append="ro rootfstype=ext4 console=ttyS0,115200 console=tty0"


### PR DESCRIPTION
wic is nice. Using the 'wic' executable to generate the rootfs is great
but integrating the whole thing with bitbake is better. This is a simple
example that creates a GPT partitioned disk that boots using grub-efi.
The rootfs comes from from core-image-tpm with a kernel config to boot
it readonly. There's a bit of swap space too (for whatever that's
worth).

Signed-off-by: Philip Tricca <flihp@twobit.org>