### PR TITLE
wic-image-tpm: Add IMAGE_TYPEDEP on ext4 for wic fstype.

### DIFF
--- a/recipes-tpm/images/wic-image-tpm.bb
+++ b/recipes-tpm/images/wic-image-tpm.bb
@@ -9,6 +9,7 @@ require recipes-tpm/images/core-image-tpm.inc
 SRC_URI = "file://${FILE_DIRNAME}/${BPN}.wks.in"
 
 IMAGE_FSTYPES = "wic"
+IMAGE_TYPEDEP_wic = "ext4"
 
 WKS_FILE = "${BPN}.wks.in"
 WKS_FILE_DEPENDS = "dosfstools-native mtools-native gptfdisk-native"


### PR DESCRIPTION
Machine types from meta-intel (or based on them) require the user to
manually add this to their local.conf (per the instructions in
meta-intel). QEMU machine types from oe-core do not require this. Seems
more natural to have this in the wic-image-tpm recipe instead since the
wks.in file used ext4 directly.

Signed-off-by: Philip Tricca <flihp@twobit.org>