### PR TITLE
Make the strongswan bbappend compatible with 5.6+

### DIFF
--- a/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
+++ b/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
@@ -8,8 +8,8 @@ PACKAGECONFIG += " \
     imv-os \
     imc-attestation \
     imv-attestation \
-    imc-swid \
-    imv-swid \
+    imc-swima \
+    imv-swima \
     tnc-ifmap \
     tnc-imc \
     tnc-imv \
@@ -28,7 +28,8 @@ PACKAGECONFIG[imc-os] = "--enable-imc-os,--disable-imc-os,,"
 PACKAGECONFIG[imv-os] = "--enable-imv-os,--disable-imv-os,,"
 PACKAGECONFIG[imc-attestation] = "--enable-imc-attestation,--disable-imc-attestation,,"
 PACKAGECONFIG[imv-attestation] = "--enable-imv-attestation,--disable-imv-attestation,,"
-PACKAGECONFIG[imc-swid] = "--enable-imc-swid,--disable-imc-swid,,"
+PACKAGECONFIG[imc-swima] = "--enable-imc-swima,--disable-imc-swima,json-c,"
+PACKAGECONFIG[imv-swima] = "--enable-imv-swima,--disable-imv-swima,json-c,"
 PACKAGECONFIG[tnc-ifmap] = "--enable-tnc-ifmap,--disable-tnc-ifmap,libxml2,"
 PACKAGECONFIG[tnc-imc] = "--enable-tnc-imc,--disable-tnc-imc,,"
 PACKAGECONFIG[tnc-imv] = "--enable-tnc-imv,--disable-tnc-imv,,"

--- a/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
+++ b/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
@@ -36,7 +36,7 @@ PACKAGECONFIG[tnc-pdp] = "--enable-tnc-pdp,--disable-tnc-pdp,,"
 PACKAGECONFIG[tnccs-11] = "--enable-tnccs-11,--disable-tnccs-11,libxml2,"
 PACKAGECONFIG[tnccs-20] = "--enable-tnccs-20,--disable-tnccs-20,,"
 PACKAGECONFIG[tnccs-dynamic] = "--enable-tnccs-dynamic,--disable-tnccs-dynamic,,"
-PACKAGECONFIG[tss-trousers] = "--with-tss=trousers,,libtspi,"
+PACKAGECONFIG[tss-trousers] = "--enable-tss-trousers,,libtspi,"
 
 FILES_${PN} += "${libdir}/ipsec/imcvs/*.so ${datadir}/regid.2004-03.org.strongswan"
 FILES_${PN}-dbg += "${libdir}/ipsec/imcvs/.debug"


### PR DESCRIPTION
The bbappend for strongswan has been broken by the strongswan project since version 5.5.

From a look at the history of their configure options [1], we can see that the option to enable trousers changed in 5.5.0.

Version 5.6.0 brought renames from swid to swima.

This pull request includes 2 patches to address these two changes.

The sumo branch of meta-openembedded currently builds strongswan 5.6.2. The dunfell branch builds 5.8.4. The master branch builds 5.9.2. These patches at least make the meta-measured bbappend for strongswan support the sumo branch. Looking at [1] it appears there were no breaking configure options after 5.6.0, so this should also work on dunfell and master.

[1] - https://wiki.strongswan.org/projects/strongswan/wiki/Autoconf/diff?utf8=%E2%9C%93&version=60&version_from=36&commit=View+differences