### PR TITLE
Update tmp2-abrmd SRC_URI protocol to https

### DIFF
--- a/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
+++ b/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
@@ -2,7 +2,7 @@ include ${BPN}.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI += "git://github.com/01org/tpm2-abrmd;protocol=git;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
+SRC_URI += "https://github.com/01org/tpm2-abrmd;protocol=https;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
 
 # https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Github no longer support unauthenticated git protocol.
Change to https

Refer https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.