### PR TITLE
Update protocol from git to https

### DIFF
--- a/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
+++ b/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
@@ -2,7 +2,7 @@ include ${BPN}.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI += "git://github.com/01org/tpm2-abrmd;protocol=git;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
+SRC_URI += "git://github.com/01org/tpm2-abrmd;protocol=https;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
 
 # https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Signed-off-by: AhmadX Syafiq bin Azmi <ahmadx.syafiq.bin.azmi@intel.com>